### PR TITLE
configure CLI using ENV configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ trieve login
 
 Then, you can use any of the available commands to interact with the Trieve service.
 
+## Setting Configuration via Environment Variables
+
+You can configure the Trieve CLI using environment variables. This is especially useful for CI environments where you want to avoid interactive configuration.
+
+To configure the Trieve CLI using environment variables, set the following environment variables and run the desired command:
+
+- **TRIEVE_NO_PROFILE=true**
+- **TRIEVE_API_KEY=your_api_key**
+- **TRIEVE_ORG_ID=your_organization_id**
+- **TRIEVE_API_URL=your_api_url** (optional, defaults to https://api.trieve.ai)
+
+#### Example:
+
+```sh
+  TRIEVE_NO_PROFILE=true TRIEVE_API_KEY=api_key TRIEVE_ORG_ID=org_id trieve dataset list
+```
+
+With this configuration, you can skip the trieve login step and directly use the CLI commands.
+
 ## Features
 
 ### General

--- a/src/commands/configure.rs
+++ b/src/commands/configure.rs
@@ -1,5 +1,5 @@
 use std::{
-    fmt,
+    env, fmt,
     ops::{Deref, DerefMut},
 };
 
@@ -14,6 +14,7 @@ use trieve_client::{
     },
     models::{Organization, SlimUser},
 };
+use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
 pub struct TrieveConfiguration {
@@ -73,6 +74,27 @@ impl Default for TrieveConfiguration {
             organization_id: uuid::Uuid::nil(),
             api_url: "https://api.trieve.ai".to_string(),
         }
+    }
+}
+
+impl TrieveConfiguration {
+    pub(crate) fn from_env() -> Result<Self, Box<dyn std::error::Error>> {
+        let api_key = env::var("TRIEVE_API_KEY").unwrap_or_else(|_| String::new());
+        let organization_id = env::var("TRIEVE_ORG_ID").unwrap_or_else(|_| String::new());
+        let api_url =
+            env::var("TRIEVE_API_URL").unwrap_or_else(|_| "https://api.trieve.ai".to_string());
+
+        let organization_id = if !organization_id.is_empty() {
+            organization_id.parse()?
+        } else {
+            Uuid::nil()
+        };
+
+        Ok(Self {
+            api_key,
+            organization_id,
+            api_url,
+        })
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to configure the Trieve CLI using environment variables. This is especially useful for CI environments where you want to avoid interactive configuration.

For example, you can run this command without executing `trieve login` beforehand:

```
  TRIEVE_NO_PROFILE=true TRIEVE_API_KEY=api_key TRIEVE_ORG_ID=org_id trieve dataset list
```